### PR TITLE
Fixed Android compilation

### DIFF
--- a/Library/Android.mk
+++ b/Library/Android.mk
@@ -12,6 +12,9 @@ Sources/GAFMovieClip.cpp \
 Sources/GAFMask.cpp \
 Sources/GAFAssetTextureManager.cpp \
 Sources/GAFTimeline.cpp \
+Sources/GAFTimelineAction.cpp \
+Sources/GAFTextField.cpp \
+Sources/GAFTextData.cpp \
 Sources/GAFAnimationFrame.cpp \
 Sources/GAFAnimationSequence.cpp \
 Sources/GAFAsset.cpp \
@@ -21,8 +24,6 @@ Sources/GAFLoader.cpp \
 Sources/GAFShaderManager.cpp \
 Sources/GAFQuadCommand.cpp \
 Sources/GAFSprite.cpp \
-Sources/GAFSpriteWithAlpha.cpp \
-Sources/GAFStencilMaskSprite.cpp \
 Sources/GAFStream.cpp \
 Sources/GAFSubobjectState.cpp \
 Sources/GAFTextureAtlas.cpp \
@@ -38,7 +39,8 @@ Sources/TagDefineNamedParts.cpp \
 Sources/TagDefineSequences.cpp \
 Sources/TagDefineStage.cpp \
 Sources/TagDefineAnimationFrames2.cpp\
-Sources/TagDefineTimeline.cpp
+Sources/TagDefineTimeline.cpp \
+Sources/TagDefineTextField.cpp 
 
 LOCAL_C_INCLUDES := \
 $(LOCAL_PATH)/../../../cocos \

--- a/Library/Sources/GAFFilterManager.cpp
+++ b/Library/Sources/GAFFilterManager.cpp
@@ -184,9 +184,8 @@ cocos2d::Texture2D* GAFFilterManager::renderBlurTexture(cocos2d::Sprite* sprite,
 {
     GLProgram* program = GAFShaderManager::getProgram(GAFShaderManager::EPrograms::Blur);
 
-    GAFBlurFilterData* f = static_cast<GAFBlurFilterData*>(filter);
-    const float blurRadiusX = (f->blurSize.width / 4.f);
-    const float blurRadiusY = (f->blurSize.height / 4.f);
+    const float blurRadiusX = (filter->blurSize.width / 4.f);
+    const float blurRadiusY = (filter->blurSize.height / 4.f);
 
     Size textureSize = sprite->getTextureRect().size;
     Size rTextureSize = Size(textureSize.width + kGaussianKernelSize * blurRadiusX,

--- a/Library/Sources/GAFObject.cpp
+++ b/Library/Sources/GAFObject.cpp
@@ -592,7 +592,7 @@ void GAFObject::setReversed(bool reversed)
         {
             continue;
         }
-        obj->setLooped(reversed);
+        obj->setReversed(reversed);
     }
 }
 


### PR DESCRIPTION
- Microfixes:
  removed redundant cast
  fixed copy-paste based typo "looped" => "reversed"
